### PR TITLE
Add intel 8086 emulator in tools

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -26,7 +26,7 @@ Would like to participate in the Lang Jam and need a few resources on creating a
 * [Template for a Racket language in Racket](https://github.com/racket-templates/lang) - A working example of a #lang language you can use as a starting point for creating your own #lang language. (Template based on `xlang` A language of combinators and numeric constants, implemented in Racket.)
 * [Sham: A DSL for runtime code generation in Racket](https://github.com/rjnw/sham) - use this to target WASM or LLVM
 * [RLMeta](http://rickardlindberg.me/projects/rlmeta/) - RLMeta is a programming language in which you write grammars. Grammars have rules that specify how to match objects from an input stream and specify what should happen when objects are matched. It can be used to write lexers, parsers, tree transformers, code generators, and similar tools. The RLMeta compiler is implemented in RLMeta itself which makes it a metacompiler. (There are multiple versions of RLMeta that all live in blog posts and the theory behind them is quite well documented.)
-* [Intel 8086 emulator](https://github.com/YJDoc2/8086-Emulator/) and [8086 emulator web](https://github.com/YJDoc2/8086-emulator-web/) - An emulator which supports almost all of intel 8086 instructions, as well as have web view to see live state updates.
+* [Online Intel 8086 emulator](https://yjdoc2.github.io/8086-emulator-web/compile) - a web-based assembler IDE with live debugging
 
 ## Books
 

--- a/resources.md
+++ b/resources.md
@@ -26,6 +26,7 @@ Would like to participate in the Lang Jam and need a few resources on creating a
 * [Template for a Racket language in Racket](https://github.com/racket-templates/lang) - A working example of a #lang language you can use as a starting point for creating your own #lang language. (Template based on `xlang` A language of combinators and numeric constants, implemented in Racket.)
 * [Sham: A DSL for runtime code generation in Racket](https://github.com/rjnw/sham) - use this to target WASM or LLVM
 * [RLMeta](http://rickardlindberg.me/projects/rlmeta/) - RLMeta is a programming language in which you write grammars. Grammars have rules that specify how to match objects from an input stream and specify what should happen when objects are matched. It can be used to write lexers, parsers, tree transformers, code generators, and similar tools. The RLMeta compiler is implemented in RLMeta itself which makes it a metacompiler. (There are multiple versions of RLMeta that all live in blog posts and the theory behind them is quite well documented.)
+* [Intel 8086 emulator](https://github.com/YJDoc2/8086-Emulator/) and [8086 emulator web](https://github.com/YJDoc2/8086-emulator-web/) - An emulator which supports almost all of intel 8086 instructions, as well as have web view to see live state updates.
 
 ## Books
 


### PR DESCRIPTION
Add link for an Intel 8086 emulator, having both cmd based and web based version. This supports almost all of Intel 8086 instructions, and I thought this might be useful if someone wants to try making something that targets assembly, but does not want to work on complex assembly of modern processors.

**Disclaimer** :  I am one of the main authors of both of these, and was contemplating if this would be too "self-promotional" to add. If you think this is so, or that this does not belong in the resource section, please feel free to not merge and close this PR. I opened this in case if you think this would be helpful to someone who might want to target assembly.

Thanks :)